### PR TITLE
add-authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@angular/cli": "^17.1.0",
         "@angular/compiler-cli": "^17.1.0",
         "@types/jasmine": "~5.1.0",
+        "@types/uuid": "^9.0.8",
         "jasmine-core": "~5.1.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
@@ -4499,6 +4500,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@angular/cli": "^17.1.0",
     "@angular/compiler-cli": "^17.1.0",
     "@types/jasmine": "~5.1.0",
+    "@types/uuid": "^9.0.8",
     "jasmine-core": "~5.1.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,7 +1,20 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import {NotFoundComponent} from "./not-found/not-found.component";
+import {DashboardComponent} from "./dashboard/dashboard.component";
+import {LoginScreenComponent} from "./login-screen/login-screen.component";
+import {UnauthorizedComponent} from "./unauthorized/unauthorized.component";
+import {authorizationGuard} from "./authorization.guard";
+import {CreateAccountComponent} from "./create-account/create-account.component";
 
-const routes: Routes = [];
+const routes: Routes = [
+  { path: '', redirectTo: '/login', pathMatch: 'full' },
+  { path: 'login', component: LoginScreenComponent },
+  { path: 'dashboard', component: DashboardComponent, canActivate: [authorizationGuard] },
+  { path: 'createAccount', component: CreateAccountComponent },
+  { path: 'unauthorized', component: UnauthorizedComponent },
+  { path: '**', pathMatch: 'full', component: NotFoundComponent },
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,0 +1,1 @@
+<router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,5 +6,5 @@ import { Component } from '@angular/core';
   styleUrl: './app.component.css'
 })
 export class AppComponent {
-  title = '30-by-30-step8';
+  title = 'Craft Beer Tracker';
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,21 +1,73 @@
-import { NgModule } from '@angular/core';
+import {NgModule} from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { DashboardComponent } from './dashboard/dashboard.component';
+import { LoginScreenComponent } from './login-screen/login-screen.component';
+import { CheckInDetailViewComponent } from './check-in-detail-view/check-in-detail-view.component';
+import { CheckInListViewComponent } from './check-in-list-view/check-in-list-view.component';
+import { NotFoundComponent } from './not-found/not-found.component';
+import { MatToolbar } from "@angular/material/toolbar";
+import { MatFormField, MatFormFieldModule, MatLabel } from "@angular/material/form-field";
+import { MatIcon } from "@angular/material/icon";
+import { MatInput } from "@angular/material/input";
+import { MatButton, MatIconButton } from "@angular/material/button";
+import { MatMenuItem, MatMenuModule } from "@angular/material/menu";
+import { MatDrawer, MatDrawerContainer } from "@angular/material/sidenav";
+import { MatDivider } from "@angular/material/divider";
+import { MatActionList, MatListItem } from "@angular/material/list";
+import { FormsModule } from "@angular/forms";
+import { MatRadioButton, MatRadioGroup } from "@angular/material/radio";
+import { MatOption, MatSelect } from "@angular/material/select";
+import { MatCard } from "@angular/material/card";
+import { MatChipListbox, MatChipOption } from "@angular/material/chips";
+import { HttpClientModule } from "@angular/common/http";
+import { UnauthorizedComponent } from './unauthorized/unauthorized.component';
+import { CreateAccountComponent } from './create-account/create-account.component';
 
 @NgModule({
   declarations: [
-    AppComponent
+    AppComponent,
+    DashboardComponent,
+    LoginScreenComponent,
+    CheckInDetailViewComponent,
+    CheckInListViewComponent,
+    NotFoundComponent,
+    UnauthorizedComponent,
+    CreateAccountComponent
   ],
   imports: [
     BrowserModule,
-    AppRoutingModule
+    AppRoutingModule,
+    BrowserAnimationsModule,
+    MatToolbar,
+    MatFormField,
+    MatIcon,
+    MatInput,
+    MatIconButton,
+    MatFormFieldModule,
+    MatButton,
+    MatLabel,
+    MatMenuModule,
+    MatMenuItem,
+    MatDrawerContainer,
+    MatDrawer,
+    MatDivider,
+    MatActionList,
+    MatListItem,
+    FormsModule,
+    MatRadioGroup,
+    MatRadioButton,
+    MatSelect,
+    MatOption,
+    MatCard,
+    MatChipListbox,
+    MatChipOption,
+    HttpClientModule,
   ],
-  providers: [
-    provideAnimationsAsync()
-  ],
+  providers: [],
   bootstrap: [AppComponent]
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/app/authentication.service.spec.ts
+++ b/src/app/authentication.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AuthenticationService } from './authentication.service';
+
+describe('AuthenticationService', () => {
+  let service: AuthenticationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AuthenticationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/authentication.service.ts
+++ b/src/app/authentication.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthenticationService {
+  isAuthenticated = false;
+
+  setIsAuthenticated(authenticated: boolean): void {
+    this.isAuthenticated = authenticated;
+
+    // set a copy in session storage so we don't get Unauthorized on a page refresh
+    sessionStorage.setItem('authenticated', authenticated ? 'true' : 'false');
+  }
+
+  getIsAuthenticated(): boolean {
+    const authenticated = sessionStorage.getItem('authenticated');
+
+    return this.isAuthenticated || authenticated === 'true';
+  }
+}

--- a/src/app/authorization.guard.spec.ts
+++ b/src/app/authorization.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { authorizationGuard } from './authorization.guard';
+
+describe('authorizationGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => authorizationGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/authorization.guard.ts
+++ b/src/app/authorization.guard.ts
@@ -1,0 +1,15 @@
+import {inject} from "@angular/core";
+import {AuthenticationService} from "./authentication.service";
+import {Router} from "@angular/router";
+
+export const authorizationGuard = () => {
+  const authService = inject(AuthenticationService);
+  const router = inject(Router);
+
+  if (authService.getIsAuthenticated()) {
+    return true;
+  }
+
+  // If we have not successfully logged in, then redirect to the unauthorized page.
+  return router.parseUrl('/unauthorized');
+};

--- a/src/app/beer-type.ts
+++ b/src/app/beer-type.ts
@@ -1,0 +1,9 @@
+export enum BeerType {
+    IPA = "IPA",
+    STOUT = "Stout",
+    SOUR = "Sour",
+    AMBER = "Amber",
+    BELGIAN = "Belgian",
+    RED = "Red",
+    LAGER = "Lager",
+}

--- a/src/app/check-in-detail-view/check-in-detail-view.component.css
+++ b/src/app/check-in-detail-view/check-in-detail-view.component.css
@@ -1,0 +1,28 @@
+.checkin-form {
+    border-style: solid;
+    padding: .5rem;
+    height: 70vh;
+    border-radius: .5rem;
+}
+
+.radio-buttons {
+    margin-bottom: .625rem;
+}
+
+.flex-table {
+    display: flex;
+    justify-content: space-between;
+    margin-top: .625rem
+}
+
+.edit-add-form-title {
+    font-size: x-large;
+    margin-bottom: 1rem;
+    margin-left: .5rem;
+}
+
+.edit-add-checkin-container {
+    margin-top: 1.5rem;
+    height: 60vh;
+    flex: 1 1 0;
+}

--- a/src/app/check-in-detail-view/check-in-detail-view.component.html
+++ b/src/app/check-in-detail-view/check-in-detail-view.component.html
@@ -1,0 +1,111 @@
+<div class="edit-add-checkin-container">
+    <mat-card>
+        <div class="checkin-form">
+            <div class="edit-add-form-title">
+                <div *ngIf="selectedCheckIn.id; else elseBlock">
+                    Edit Check-In
+                </div>
+                <ng-template #elseBlock>
+                    Create New Check-In
+                </ng-template>
+            </div>
+            <mat-divider></mat-divider>
+            <table class="flex-table">
+                <tr>
+                    <td>
+                        <!--Brewery Name-->
+                        <mat-form-field class="brewery-name-input">
+                            <mat-label>Brewery</mat-label>
+                            <input matInput [(ngModel)]="selectedCheckIn.brewery" name="brewery">
+                        </mat-form-field>
+                    </td>
+                    <td>
+                        <!--Beer Name-->
+                        <mat-form-field class="beer-name-input">
+                            <mat-label>Beer Name</mat-label>
+                            <input matInput [(ngModel)]="selectedCheckIn.beerName" name="beer-name">
+                        </mat-form-field>
+                    </td>
+                </tr>
+            </table>
+
+            <!--Serving Style-->
+            <div class="radio-buttons">
+                <label for="style">Style: </label>
+                <mat-radio-group
+                        color="primary"
+                        id="style"
+                        aria-label="Serving Style"
+                        [(ngModel)]="selectedCheckIn.servingStyle"
+                        name="style"
+                >
+                    <mat-radio-button *ngFor="let servingStyle of servingStyles" class="radio-button"
+                                      [value]="servingStyle">{{ servingStyle }}
+                    </mat-radio-button>
+
+                </mat-radio-group>
+            </div>
+
+            <!--Beer Type Dropdown-->
+            <div class="beer-type-select">
+                <mat-form-field>
+                    <mat-label>Beer Type</mat-label>
+                    <mat-select [(value)]="selectedCheckIn.beerType" [compareWith]="isSameBeerType">
+                        <mat-option *ngFor="let beerType of beerTypes" [value]="beerType">{{ beerType }}</mat-option>
+                    </mat-select>
+                </mat-form-field>
+            </div>
+
+            <!--Location Drop Down-->
+            <div class="location-select">
+                <mat-form-field>
+                    <mat-label>Location</mat-label>
+                    <mat-select [(value)]="selectedCheckIn.location" [compareWith]="isSameLocation">
+                        <mat-option *ngFor="let l of location" [value]="l">{{ l }}</mat-option>
+                    </mat-select>
+                </mat-form-field>
+            </div>
+
+            <!--Rating-->
+            <div class="radio-buttons">
+                <label for="rating">Rating: </label>
+                <mat-radio-group
+                        color="primary"
+                        id="rating"
+                        aria-label="rating"
+                        [(ngModel)]="selectedCheckIn.rating"
+                        name="rating"
+                >
+                    <mat-radio-button *ngFor="let rating of ratings" class="radio-button"
+                                      [value]="rating">{{ rating }}
+                    </mat-radio-button>
+
+                </mat-radio-group>
+            </div>
+
+            <!--Review Section-->
+            <div class="review-text-area">
+                <mat-form-field>
+                    <mat-label>How was it?</mat-label>
+                    <textarea
+                            matInput
+                            name="review"
+                            [(ngModel)]="selectedCheckIn.review"
+                            [value]="selectedCheckIn.review || '' "
+                    >
+                        </textarea>
+                </mat-form-field>
+            </div>
+            <div class="spacer"></div>
+
+            <!--Add/Edit button-->
+            <button mat-stroked-button color="primary"
+                    (click)="selectedCheckIn.id ? editCheckIn.emit(selectedCheckIn) : addCheckIn.emit(selectedCheckIn)
+                      " [disabled]="isButtonDisabled"
+            >
+                {{ selectedCheckIn.id ? 'Edit' : 'Add' }} Check-In
+            </button>
+        </div>
+    </mat-card>
+</div>
+

--- a/src/app/check-in-detail-view/check-in-detail-view.component.spec.ts
+++ b/src/app/check-in-detail-view/check-in-detail-view.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CheckInDetailViewComponent } from './check-in-detail-view.component';
+
+describe('CheckInDetailViewComponent', () => {
+  let component: CheckInDetailViewComponent;
+  let fixture: ComponentFixture<CheckInDetailViewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CheckInDetailViewComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(CheckInDetailViewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/check-in-detail-view/check-in-detail-view.component.ts
+++ b/src/app/check-in-detail-view/check-in-detail-view.component.ts
@@ -1,0 +1,39 @@
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {CheckIn} from "../check-in";
+
+@Component({
+  selector: 'app-check-in-detail-view',
+  templateUrl: './check-in-detail-view.component.html',
+  styleUrl: './check-in-detail-view.component.css'
+})
+export class CheckInDetailViewComponent {
+  @Input() selectedCheckIn!: CheckIn;
+  @Input() beerTypes!: string[];
+  @Input() servingStyles!: string[];
+  @Input() location!: string[];
+  @Input() ratings!: number[];
+  @Output() editCheckIn: EventEmitter<CheckIn> = new EventEmitter<CheckIn>();
+  @Output() addCheckIn: EventEmitter<CheckIn> = new EventEmitter<CheckIn>();
+
+  isSameBeerType(str1: string, str2: string): boolean {
+    return str1 === str2;
+  }
+
+  isSameLocation(str1: string, str2: string): boolean {
+    return str1 === str2;
+  }
+
+  get isButtonDisabled(): boolean {
+    const checkIn = this.selectedCheckIn;
+
+    return this.isEmpty(checkIn.brewery) ||
+        this.isEmpty(checkIn.beerName) ||
+        this.isEmpty(checkIn.servingStyle) ||
+        this.isEmpty(checkIn.beerType) ||
+        checkIn.rating === undefined;
+  }
+
+  private isEmpty(str: string): boolean {
+    return str === '' || str === undefined;
+  }
+}

--- a/src/app/check-in-list-view/check-in-list-view.component.css
+++ b/src/app/check-in-list-view/check-in-list-view.component.css
@@ -1,0 +1,59 @@
+.checkins-container {
+    font-size: x-large;
+    margin-top: 1.5rem;
+    border-style: solid;
+    padding: .5rem;
+    height: 70vh;
+    border-radius: .5rem;
+    overflow-y: scroll;
+}
+
+.else-list-block-text {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: medium;
+    margin: .5rem;
+    span {
+        margin-left: .25rem;
+    }
+}
+
+.checkin-item {
+    min-height: 80px;
+    display: inline-block;
+}
+
+.checkins-title {
+    margin-bottom: 1rem;
+    margin-left: .5rem;
+    display: flex;
+    flex: 1 0 auto;
+    .remove-all {
+        border-radius: 1rem;
+        height: auto;
+        min-width: auto;
+        margin-left: 1rem;
+    }
+}
+
+.flex-box {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.style-filters {
+    margin-bottom: .5rem;
+    margin-left: .5rem;
+    font-size: medium;
+    .style-flex {
+        margin-left: .5rem;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        span {
+            font-size: x-large;
+        }
+    }
+}

--- a/src/app/check-in-list-view/check-in-list-view.component.html
+++ b/src/app/check-in-list-view/check-in-list-view.component.html
@@ -1,0 +1,51 @@
+<div class="checkins-container">
+    <mat-card>
+        <div class="checkins-header">
+            <div class="checkins-title">
+                Number of Check-Ins: {{ checkIns.length }}
+                <button mat-stroked-button class="remove-all" color="primary" (click)="removeAllCheckIns.emit()">
+                    Remove All
+                </button>
+            </div>
+
+            <!--Style Filter Chips-->
+            <div class="style-filters">
+                <mat-chip-listbox (change)="doFilter($event)" aria-label="style selection">
+                    <div class="style-flex">
+                        <span>Filter by:</span> <mat-chip-option *ngFor="let style of servingStyles">{{ style }}</mat-chip-option>
+                    </div>
+                </mat-chip-listbox>
+            </div>
+            <mat-divider></mat-divider>
+        </div>
+
+        <!--List of Checkins-->
+        <div class="checkins-list" *ngIf="visibleCheckInList.length; else elseListBlock">
+            <div *ngFor="let checkIn of visibleCheckInList">
+                <mat-action-list>
+                    <div class="flex-box">
+                        <button mat-list-item class="checkin-item" (click)="selectCheckIn.emit(checkIn)">
+                            <b>Name:</b> {{ checkIn.brewery }} {{ checkIn.beerName }}
+                            <div>
+                                <b>Rating:</b> {{ checkIn.rating }}
+                            </div>
+                            <div>
+                                <b>Style:</b> {{ checkIn.servingStyle }}
+                            </div>
+                        </button>
+                        <button class="remove" mat-button (click)="deleteCheckIn.emit(checkIn)">
+                            <mat-icon>delete</mat-icon>
+                        </button>
+                    </div>
+                </mat-action-list>
+                <mat-divider></mat-divider>
+            </div>
+        </div>
+        <ng-template #elseListBlock>
+            <p class="else-list-block-text">
+                No Check-Ins <span><mat-icon>mood_bad</mat-icon></span>
+            </p>
+        </ng-template>
+    </mat-card>
+</div>
+

--- a/src/app/check-in-list-view/check-in-list-view.component.spec.ts
+++ b/src/app/check-in-list-view/check-in-list-view.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CheckInListViewComponent } from './check-in-list-view.component';
+
+describe('CheckInListViewComponent', () => {
+  let component: CheckInListViewComponent;
+  let fixture: ComponentFixture<CheckInListViewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CheckInListViewComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(CheckInListViewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/check-in-list-view/check-in-list-view.component.ts
+++ b/src/app/check-in-list-view/check-in-list-view.component.ts
@@ -1,0 +1,44 @@
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {CheckIn} from "../check-in";
+import {MatChipListboxChange} from "@angular/material/chips";
+
+@Component({
+  selector: 'app-check-in-list-view',
+  templateUrl: './check-in-list-view.component.html',
+  styleUrl: './check-in-list-view.component.css'
+})
+export class CheckInListViewComponent {
+  @Input() checkIns!: CheckIn[];
+  @Input() servingStyles!: string[];
+  @Output() deleteCheckIn: EventEmitter<CheckIn> = new EventEmitter<CheckIn>();
+  @Output() selectCheckIn: EventEmitter<CheckIn> = new EventEmitter<CheckIn>();
+  @Output() removeAllCheckIns: EventEmitter<void> = new EventEmitter<void>();
+  filteredCheckIns: CheckIn[] = [];
+
+  get visibleCheckInList(): CheckIn[] {
+    if (!this.checkIns.length) {
+      return [];
+    }
+
+    const difference = this.checkIns.filter(c => this.filteredCheckIns.includes(c));
+
+    /*
+      Check to see if the check-in list is different then the current filtered list.
+      If that is the case then we have deleted a check-in while we were filtered. Update the list accordingly.
+     */
+    if (difference.length !== this.filteredCheckIns.length) {
+      this.filteredCheckIns = difference;
+    }
+
+    return this.filteredCheckIns.length ? this.filteredCheckIns : this.checkIns;
+  }
+
+  doFilter(changes: MatChipListboxChange): void {
+    // If there is a value, a chip has been selected, so we need to filter. Otherwise, it is not selected, so we remove the filter.
+    if (changes.value) {
+      this.filteredCheckIns = this.checkIns.filter(c => c.servingStyle === changes.value);
+    } else {
+      this.filteredCheckIns = [];
+    }
+  }
+}

--- a/src/app/check-in.service.spec.ts
+++ b/src/app/check-in.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CheckInService } from './check-in.service';
+
+describe('CheckInService', () => {
+  let service: CheckInService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CheckInService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/check-in.service.ts
+++ b/src/app/check-in.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@angular/core';
+import {CheckIn} from "./check-in";
+import {HttpClient} from "@angular/common/http";
+import {catchError, map, Observable, of} from "rxjs";
+import {v4} from "uuid";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CheckInService {
+  checkIns: CheckIn[] = [];
+  selectedCheckIn: CheckIn = {} as CheckIn;
+  private url = 'https://mock-json-server-five.vercel.app/checkIns';
+
+  constructor(private http: HttpClient) {}
+
+  getCheckIns() {
+    this.http.get<CheckIn[]>(this.url)
+        .pipe(
+            // return an empty array here if there was an error on the request
+            catchError(this.handleError<CheckIn[]>([]))
+        ).subscribe(resp => this.checkIns = resp);
+  }
+
+  deleteCheckIn(checkIn: CheckIn): void {
+    this.checkIns = this.checkIns.filter(c => c.id !== checkIn.id);
+  }
+
+  removeAllCheckIns(): void {
+    this.checkIns = [];
+    this.selectedCheckIn = {} as CheckIn;
+  }
+
+  editCheckIn(checkIn: CheckIn): void {
+    const index = this.checkIns.findIndex(c => c.id === checkIn.id);
+
+    // -1 is not found
+    if (index !== -1) {
+      this.checkIns[index] = checkIn;
+    }
+
+    this.selectedCheckIn = {} as CheckIn;
+  }
+
+  selectCheckIn(checkIn: CheckIn): void {
+    // Select
+    if (!this.selectedCheckIn || this.selectedCheckIn.id !== checkIn.id) {
+      this.selectedCheckIn = {...checkIn};
+    } else {
+      // Unselect
+      this.selectedCheckIn = {} as CheckIn;
+    }
+  }
+
+  addCheckIn(checkIn: CheckIn): void {
+    const toAdd: CheckIn = {...checkIn};
+    toAdd.id = v4();
+
+    this.checkIns.push(toAdd);
+    this.selectedCheckIn = {} as CheckIn;
+  }
+
+  private handleError<T>(result?: T) {
+    return (error: any): Observable<T> => {
+
+      console.error(error); // log to console instead
+
+      // Let the app keep running by returning an empty result.
+      return of(result as T);
+    };
+  }
+}

--- a/src/app/check-in.ts
+++ b/src/app/check-in.ts
@@ -1,0 +1,14 @@
+import {BeerType} from "./beer-type";
+import {ServingStyle} from "./serving-style";
+import {Location} from "./location";
+
+export interface CheckIn {
+    id: string,
+    brewery: string,
+    beerName: string,
+    beerType: BeerType,
+    review: string,
+    rating: number,
+    servingStyle: ServingStyle,
+    location: Location,
+}

--- a/src/app/create-account/create-account.component.css
+++ b/src/app/create-account/create-account.component.css
@@ -1,0 +1,39 @@
+.login-form {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    min-height: 70vh;
+}
+
+.password-input{
+    min-width: 250px;
+}
+
+.username-input {
+    min-width: 250px;
+    margin-bottom: .5rem;
+}
+
+.app-title {
+    margin: auto;
+    display: flex;
+    align-items: center;
+
+    .icon {
+        margin-left: .5rem;
+    }
+}
+
+.login-text {
+    margin-bottom: 1.25rem;
+}
+
+.account-exists {
+    margin-top: 2rem;
+    color: red;
+}
+
+.login-button {
+    margin-top: 2rem;
+}

--- a/src/app/create-account/create-account.component.html
+++ b/src/app/create-account/create-account.component.html
@@ -1,0 +1,70 @@
+<mat-toolbar color="primary" class="top-nav">
+    <span class="app-title">
+        Craft Beer Tracker
+        <mat-icon class="icon">sports_bar</mat-icon>
+    </span>
+</mat-toolbar>
+<div class="login-form">
+    <div class="login-text"><span>Create New Account</span></div>
+
+    <!--Username-->
+    <mat-form-field hintLabel="Max 10 characters" appearance="outline" class="username-input">
+        <mat-label>Username</mat-label>
+        <input matInput #input maxlength="10"  [(ngModel)]="username" name="username" [required]="true">
+        <mat-hint align="end">{{input.value.length}}/10</mat-hint>
+    </mat-form-field>
+
+    <!--Password-->
+    <mat-form-field appearance="outline" class="password-input">
+        <mat-label>Password</mat-label>
+        <input matInput
+               [type]="hidePassword ? 'password' : 'text'"
+               [(ngModel)]="password"
+               name="password"
+               [required]="true"
+               [minlength]="5"
+        >
+        <button mat-icon-button
+                matSuffix
+                (click)="hidePassword = !hidePassword"
+                [attr.aria-label]="'Hide password'"
+                [attr.aria-pressed]="hidePassword"
+        >
+            <mat-icon>{{ hidePassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+        </button>
+    </mat-form-field>
+
+    <!--Confirm Password-->
+    <mat-form-field appearance="outline" class="confirm-password-input">
+        <mat-label>Confirm Password</mat-label>
+        <input matInput
+               [type]="hideConfirmPassword ? 'password' : 'text'"
+               [(ngModel)]="confirmPassword"
+               name="confirm-password"
+               [required]="true"
+               [minlength]="5"
+        >
+        <button mat-icon-button
+                matSuffix
+                (click)="hideConfirmPassword = !hideConfirmPassword"
+                [attr.aria-label]="'Hide password'"
+                [attr.aria-pressed]="hideConfirmPassword"
+        >
+            <mat-icon>{{ hideConfirmPassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+        </button>
+        <mat-hint>At least 5 characters, 1 uppercase, 1 special character</mat-hint>
+    </mat-form-field>
+
+    <button
+            class="login-button"
+            mat-stroked-button
+            color="primary"
+            (click)="createAccount()"
+            [disabled]="isDisabled"
+    >
+        Create Account
+    </button>
+    <div class="account-exists" *ngIf="accountExists">
+        Account Exists. Please try a different username.
+    </div>
+</div>

--- a/src/app/create-account/create-account.component.spec.ts
+++ b/src/app/create-account/create-account.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateAccountComponent } from './create-account.component';
+
+describe('CreateAccountComponent', () => {
+  let component: CreateAccountComponent;
+  let fixture: ComponentFixture<CreateAccountComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CreateAccountComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(CreateAccountComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/create-account/create-account.component.ts
+++ b/src/app/create-account/create-account.component.ts
@@ -1,0 +1,70 @@
+import {Component} from '@angular/core';
+import {UserService} from "../user.service";
+import {Router} from "@angular/router";
+
+@Component({
+  selector: 'app-create-account',
+  templateUrl: './create-account.component.html',
+  styleUrl: './create-account.component.css'
+})
+export class CreateAccountComponent {
+  hidePassword = true;
+  hideConfirmPassword = true;
+  username = '';
+  password = '';
+  confirmPassword = '';
+  accountExists = false;
+
+  constructor(private userService: UserService, private router: Router) {}
+
+  createAccount(): void {
+    const user = this.userService.findUserAccount({
+      username: this.username,
+      password: this.password,
+    });
+
+    if (user) {
+      this.accountExists = true;
+      return;
+    }
+
+    this.userService.createUserAccount(this.username, this.password);
+    this.router.navigate(['/login']);
+  }
+
+  get isDisabled(): boolean {
+    return this.isEmpty ||
+        !this.passwordsAreEqual ||
+        !this.hasSpecialCharacter ||
+        !this.hasUppercase ||
+        !this.hasCorrectPasswordLength;
+  }
+
+  private get isEmpty(): boolean {
+    return this.username=== '' ||
+        this.username === undefined ||
+        this.password === '' ||
+        this.password === undefined;
+  }
+
+  private get passwordsAreEqual(): boolean {
+    return this.password === this.confirmPassword;
+  }
+
+  private get hasSpecialCharacter(): boolean {
+    const regex = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]+/;
+    
+    return regex.test(this.password) || regex.test(this.confirmPassword);
+  }
+
+  private get hasUppercase(): boolean {
+    const regex = /[A-Z]+/;
+
+    return regex.test(this.password) || regex.test(this.confirmPassword);
+  }
+
+  private get hasCorrectPasswordLength(): boolean {
+    return this.password.length >= 5 || this.confirmPassword.length >= 5;
+  }
+
+}

--- a/src/app/dashboard/dashboard.component.css
+++ b/src/app/dashboard/dashboard.component.css
@@ -1,0 +1,50 @@
+.top-nav {
+    margin-bottom: 1rem;
+}
+
+.spacer {
+    flex: 1 1 auto;
+}
+
+.main-container {
+    width: 100%;
+    height: 100%;
+}
+
+.checkins-button,
+.home-button {
+    font-size: medium;
+    display: flex;
+    justify-content: left;
+    align-items: center;
+}
+
+.sidenav {
+    padding: .625rem;
+    display: flex;
+    justify-content: left;
+    width: 15%;
+}
+
+.sidenav-content {
+    display: flex;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+}
+.flex-container {
+    display: flex;
+    justify-content: space-evenly;
+    gap: 100px;
+    flex-shrink: 0;
+}
+
+.app-title {
+    margin: auto;
+    display: flex;
+    align-items: center;
+    .icon {
+        margin-left: .5rem;
+    }
+}
+

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,0 +1,60 @@
+<mat-toolbar color="primary" class="top-nav">
+    <div class="sidenav-content">
+        <button type="button" mat-button class="menu-button" (click)="drawer.toggle()">
+            <mat-icon>menu</mat-icon>
+        </button>
+    </div>
+    <span class="app-title">
+        Craft Beer Tracker
+        <mat-icon class="icon">sports_bar</mat-icon>
+    </span>
+    <span *ngIf="userService.getLoggedInUser() as user"> Welcome, {{ user }}!</span>
+    <button mat-button [matMenuTriggerFor]="menu" aria-label="profile-button">
+        <mat-icon>account_circle</mat-icon>
+    </button>
+
+    <!--Logout Button-->
+    <mat-menu #menu="matMenu">
+        <button class="logout-button" mat-menu-item (click)="logout()">Logout</button>
+    </mat-menu>
+</mat-toolbar>
+
+<mat-drawer-container class="main-container" autosize>
+    <mat-drawer #drawer class="sidenav" mode="side">
+
+        <!--Drawer Icons-->
+        <div class="home-button">
+            <button mat-icon-button color="primary" aria-label="home icon">
+                <mat-icon>home</mat-icon>
+            </button>
+            <p>Home</p>
+        </div>
+        <div class="spacer"></div>
+        <div class="checkins-button">
+            <button mat-icon-button color="primary" aria-label="checkins icon">
+                <mat-icon>list</mat-icon>
+            </button>
+            <p>Check-ins</p>
+        </div>
+    </mat-drawer>
+    <div class="flex-container">
+        <app-check-in-list-view
+                [checkIns]="checkInService.checkIns"
+                [servingStyles]="servingStyles"
+                (selectCheckIn)="checkInService.selectCheckIn($event)"
+                (deleteCheckIn)="checkInService.deleteCheckIn($event)"
+                (removeAllCheckIns)="checkInService.removeAllCheckIns()"
+        >
+        </app-check-in-list-view>
+        <app-check-in-detail-view
+                [selectedCheckIn]="checkInService.selectedCheckIn"
+                [servingStyles]="servingStyles"
+                [beerTypes]="beerTypes"
+                [ratings]="ratings"
+                [location]="location"
+                (addCheckIn)="checkInService.addCheckIn($event)"
+                (editCheckIn)="checkInService.editCheckIn($event)"
+        >
+        </app-check-in-detail-view>
+    </div>
+</mat-drawer-container>

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DashboardComponent } from './dashboard.component';
+
+describe('DashboardComponent', () => {
+  let component: DashboardComponent;
+  let fixture: ComponentFixture<DashboardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DashboardComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(DashboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,0 +1,35 @@
+import {Component, OnInit} from '@angular/core';
+import {CheckInService} from "../check-in.service";
+import {BeerType} from "../beer-type";
+import {ServingStyle} from "../serving-style";
+import {AuthenticationService} from "../authentication.service";
+import {Router} from "@angular/router";
+import {UserService} from "../user.service";
+import {Location} from "../location";
+
+@Component({
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.component.html',
+  styleUrl: './dashboard.component.css'
+})
+export class DashboardComponent implements OnInit {
+  beerTypes: string[] = Object.values(BeerType);
+  servingStyles: string[] = Object.values(ServingStyle);
+  location: string[] = Object.values(Location);
+  ratings: number[] = [1, 2, 3, 4, 5];
+
+  constructor(
+      public checkInService: CheckInService,
+      public userService: UserService,
+      private router: Router,
+      private authService:AuthenticationService) {}
+
+  ngOnInit() {
+    this.checkInService.getCheckIns();
+  }
+
+  logout(): void {
+    this.authService.setIsAuthenticated(false);
+    this.router.navigate(['/login']);
+  }
+}

--- a/src/app/location.ts
+++ b/src/app/location.ts
@@ -1,0 +1,6 @@
+export enum Location {
+    BREWERY = "Brewery",
+    RESTAURANT = "Restaurant",
+    BAR = "Bar",
+    HOME = "Home",
+}

--- a/src/app/login-screen/login-screen.component.css
+++ b/src/app/login-screen/login-screen.component.css
@@ -1,0 +1,35 @@
+.login-form {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    min-height: 70vh;
+}
+
+.login-button,
+.password-input,
+.username-input {
+    min-width: 250px;
+}
+
+.app-title {
+    margin: auto;
+    display: flex;
+    align-items: center;
+
+    .icon {
+        margin-left: .5rem;
+    }
+}
+
+.login-text {
+    margin-bottom: 1.25rem;
+}
+
+.create-account {
+    margin-top: 2rem;
+}
+
+.failed-login {
+    color: red;
+}

--- a/src/app/login-screen/login-screen.component.html
+++ b/src/app/login-screen/login-screen.component.html
@@ -1,0 +1,39 @@
+<mat-toolbar color="primary" class="top-nav">
+    <span class="app-title">
+        Craft Beer Tracker
+        <mat-icon class="icon">sports_bar</mat-icon>
+    </span>
+</mat-toolbar>
+<div class="login-form">
+    <div class="login-text"><span>Sign in to track your beers</span></div>
+
+    <!--Username-->
+    <mat-form-field appearance="outline" class="username-input">
+        <mat-label>Username</mat-label>
+        <input matInput name="username" [(ngModel)]="username" [required]="true">
+    </mat-form-field>
+
+    <!--Password-->
+    <mat-form-field appearance="outline" class="password-input">
+        <mat-label>Password</mat-label>
+        <input matInput [type]="hidePassword ? 'password' : 'text'" [(ngModel)]="password" name="password"
+               [required]="true">
+        <button mat-icon-button
+                matSuffix
+                (click)="hidePassword = !hidePassword"
+                [attr.aria-label]="'Hide password'"
+                [attr.aria-pressed]="hidePassword"
+        >
+            <mat-icon>{{ hidePassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+        </button>
+    </mat-form-field>
+    <button class="login-button" mat-stroked-button color="primary" (click)="login()" [disabled]="isDisabled">
+        Login
+    </button>
+    <div class="failed-login" *ngIf="loginFailed">
+        <p>Authentication Failed</p>
+    </div>
+    <div class="create-account">
+        Don't have an account? Create one <a [routerLink]="'/createAccount'"> here</a>
+    </div>
+</div>

--- a/src/app/login-screen/login-screen.component.spec.ts
+++ b/src/app/login-screen/login-screen.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoginScreenComponent } from './login-screen.component';
+
+describe('LoginScreenComponent', () => {
+  let component: LoginScreenComponent;
+  let fixture: ComponentFixture<LoginScreenComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LoginScreenComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(LoginScreenComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/login-screen/login-screen.component.ts
+++ b/src/app/login-screen/login-screen.component.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+import {UserService} from "../user.service";
+import {Router} from "@angular/router";
+import {AuthenticationService} from "../authentication.service";
+
+@Component({
+  selector: 'app-login-screen',
+  templateUrl: './login-screen.component.html',
+  styleUrl: './login-screen.component.css'
+})
+export class LoginScreenComponent {
+  hidePassword = true;
+  username = '';
+  password = '';
+  loginFailed = false;
+
+  constructor(private userService: UserService,
+              private authService: AuthenticationService,
+              private router: Router) {}
+
+  login() {
+    this.loginFailed = false;
+
+    const user = this.userService.findUserAccount({
+      username: this.username,
+      password: this.password,
+    });
+
+    // If user does not exist that means they haven't created their Account yet. Fail the login.
+    if (!user) {
+      this.loginFailed = true
+      return;
+    }
+
+    this.authService.setIsAuthenticated(true);
+    this.userService.setLoggedInUser(user);
+    this.router.navigate(['/dashboard'])
+  }
+
+  get isDisabled(): boolean {
+    return this.username === '' ||
+        this.username === undefined ||
+        this.password === '' ||
+        this.password === undefined;
+  }
+}
+

--- a/src/app/not-found/not-found.component.css
+++ b/src/app/not-found/not-found.component.css
@@ -1,0 +1,6 @@
+.error {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}

--- a/src/app/not-found/not-found.component.html
+++ b/src/app/not-found/not-found.component.html
@@ -1,0 +1,3 @@
+<div class="error">
+    <h1>Oops..we can't find that page. Navigate back to login <a routerLink="/login"> here </a></h1>
+</div>

--- a/src/app/not-found/not-found.component.spec.ts
+++ b/src/app/not-found/not-found.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NotFoundComponent } from './not-found.component';
+
+describe('NotFoundComponent', () => {
+  let component: NotFoundComponent;
+  let fixture: ComponentFixture<NotFoundComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NotFoundComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(NotFoundComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/not-found/not-found.component.ts
+++ b/src/app/not-found/not-found.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-not-found',
+  templateUrl: './not-found.component.html',
+  styleUrl: './not-found.component.css'
+})
+export class NotFoundComponent {
+
+}

--- a/src/app/serving-style.ts
+++ b/src/app/serving-style.ts
@@ -1,0 +1,5 @@
+export enum ServingStyle {
+    DRAFT = "Draft",
+    BOTTLE = "Bottle",
+    CAN = "Can",
+}

--- a/src/app/unauthorized/unauthorized.component.css
+++ b/src/app/unauthorized/unauthorized.component.css
@@ -1,0 +1,6 @@
+.unauthorized {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}

--- a/src/app/unauthorized/unauthorized.component.html
+++ b/src/app/unauthorized/unauthorized.component.html
@@ -1,0 +1,3 @@
+<div class="unauthorized">
+    <h1>You are not authorized to view this page. Navigate back to login <a routerLink="/login"> here </a></h1>
+</div>

--- a/src/app/unauthorized/unauthorized.component.spec.ts
+++ b/src/app/unauthorized/unauthorized.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UnauthorizedComponent } from './unauthorized.component';
+
+describe('UnauthorizedComponent', () => {
+  let component: UnauthorizedComponent;
+  let fixture: ComponentFixture<UnauthorizedComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [UnauthorizedComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(UnauthorizedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/unauthorized/unauthorized.component.ts
+++ b/src/app/unauthorized/unauthorized.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-unauthorized',
+  templateUrl: './unauthorized.component.html',
+  styleUrl: './unauthorized.component.css'
+})
+export class UnauthorizedComponent {
+
+}

--- a/src/app/user.service.spec.ts
+++ b/src/app/user.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UserService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/user.service.ts
+++ b/src/app/user.service.ts
@@ -1,0 +1,49 @@
+import {Injectable} from '@angular/core';
+import { v4 } from 'uuid'
+import {User} from "./user";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserService {
+  userAccounts : User[] = [];
+  loggedInUser = {} as User;
+
+  createUserAccount(username: string, password: string): void {
+    const id = v4();
+
+    this.userAccounts.push({id, username, password});
+
+    // Set a redundant copy in session storage so we don't lose the data on a refresh
+    sessionStorage.setItem(username, password);
+  }
+
+  findUserAccount(toFind: User): User | undefined {
+    const found = this
+        .userAccounts
+        .find(u => u.username === toFind.username && u.password === toFind.password);
+
+    if (found) {
+      return found;
+    }
+
+    // check session storage
+    const localPassword = sessionStorage.getItem(toFind.username);
+    if (localPassword && localPassword === toFind.password) {
+      return {
+        username: toFind.username,
+        password: localPassword,
+      }
+    }
+
+     return undefined;
+  }
+
+  setLoggedInUser(user: User): void {
+    this.loggedInUser = user;
+  }
+
+  getLoggedInUser(): string | null {
+    return this.loggedInUser ? this.loggedInUser.username : null;
+  }
+}

--- a/src/app/user.ts
+++ b/src/app/user.ts
@@ -1,0 +1,5 @@
+export interface User {
+    id?: string,
+    username: string,
+    password: string,
+}

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>30By30Step8</title>
+  <title>Craft Beer Tracker</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
Description of Changes:

1) Add a Create Account component and `/createAccount` route so new users can create an account to login with
2) Enforce password restrictions on the Create Account page
3) If the account already exists ,an error message will displayed and the user will have to pick another username
4) When logging in, if the credentials are incorrect an error message will be displayed
5) Create an authorization guard to ensure users have a valid session before visiting `/dashboard`
6) Create an `/unauthorized` route. If a user attempts to navigate to the `/dashboard` route before authenticating, they will see Unauthorized
7) Show the username next to the profile dropdown when the user visits the dashboard
8) When logging out, the session is killed and if the user attempts to visit `/dashboard` before logging in again, they will see Unauthorized